### PR TITLE
Fix nullable generic constraint generation bug

### DIFF
--- a/copy_with_extension_gen/lib/src/copy_with_generator.dart
+++ b/copy_with_extension_gen/lib/src/copy_with_generator.dart
@@ -73,7 +73,8 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
         if (v.immutable) {
           return '$r';
         } else {
-          return '$r ${v.type}? ${v.name},';
+          final type = v.type.endsWith('?') ? v.type : '${v.type}?';
+          return '$r $type ${v.name},';
         }
       },
     );

--- a/copy_with_extension_gen/lib/src/copy_with_generator.dart
+++ b/copy_with_extension_gen/lib/src/copy_with_generator.dart
@@ -50,7 +50,7 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
 
     final names = classElement.typeParameters
         .map(
-          (e) => nameOnly ? e.name : e.getDisplayString(withNullability: false),
+          (e) => nameOnly ? e.name : e.getDisplayString(withNullability: true),
         )
         .join(',');
     if (names.isNotEmpty) {
@@ -172,11 +172,11 @@ class _FieldInfo {
 
   _FieldInfo(ParameterElement element, ClassElement classElement)
       : name = element.name,
-        type = element.type.getDisplayString(withNullability: false),
+        type = element.type.getDisplayString(withNullability: true),
         immutable = _readFieldOptions(element, classElement).immutable,
         nullable = element.type.nullabilitySuffix != NullabilitySuffix.none,
         assert(element.name is String),
-        assert(element.type.getDisplayString(withNullability: false) is String),
+        assert(element.type.getDisplayString(withNullability: true) is String),
         assert(_readFieldOptions(element, classElement).immutable is bool);
 
   static CopyWithField _readFieldOptions(

--- a/copy_with_extension_gen/test/constants.dart
+++ b/copy_with_extension_gen/test/constants.dart
@@ -25,8 +25,13 @@ class Test_Case_Class<T extends String> {
   final T id;
   @CopyWithField(immutable: true)
   final int immutableField;
+  final List<T?> nullableGenerics;
 
-  Test_Case_Class({this.id, this.immutableField});
+  Test_Case_Class({
+    required this.id, 
+    required this.immutableField, 
+    required this.nullableGenerics,
+  });
 }
 ''';
 
@@ -42,10 +47,12 @@ part of 'test_case_class.dart';
 extension Test_Case_ClassCopyWith<T extends String> on Test_Case_Class<T> {
   Test_Case_Class<T> copyWith({
     T? id,
+    List<T?>? nullableGenerics,
   }) {
     return Test_Case_Class<T>(
       id: id ?? this.id,
       immutableField: immutableField,
+      nullableGenerics: nullableGenerics ?? this.nullableGenerics,
     );
   }
 }

--- a/copy_with_extension_test/lib/basic_test_case.dart
+++ b/copy_with_extension_test/lib/basic_test_case.dart
@@ -9,8 +9,9 @@ part 'basic_test_case.g.dart';
 class BasicClass {
   final String id;
   final String? optional;
+  final List<String?> nullableGeneric;
 
-  BasicClass({required this.id, this.optional});
+  BasicClass({required this.id, this.optional, required this.nullableGeneric});
 }
 
 @immutable

--- a/copy_with_extension_test/lib/basic_test_case.g.dart
+++ b/copy_with_extension_test/lib/basic_test_case.g.dart
@@ -9,10 +9,12 @@ part of 'basic_test_case.dart';
 extension BasicClassCopyWith on BasicClass {
   BasicClass copyWith({
     String? id,
+    List<String?>? nullableGeneric,
     String? optional,
   }) {
     return BasicClass(
       id: id ?? this.id,
+      nullableGeneric: nullableGeneric ?? this.nullableGeneric,
       optional: optional ?? this.optional,
     );
   }
@@ -22,6 +24,7 @@ extension BasicClassCopyWith on BasicClass {
   }) {
     return BasicClass(
       id: id,
+      nullableGeneric: nullableGeneric,
       optional: optional == true ? null : this.optional,
     );
   }

--- a/copy_with_extension_test/lib/subclass_test_case.g.dart
+++ b/copy_with_extension_test/lib/subclass_test_case.g.dart
@@ -36,7 +36,7 @@ extension SubClassCopyWith<T, U extends String> on SubClass<T, U> {
     T? item,
     List<T>? listWithGenericType,
     List<int>? listWithType,
-    List<Iterable<U>>? listWithTypedType,
+    List<Iterable<U>?>? listWithTypedType,
   }) {
     return SubClass<T, U>(
       aString: aString ?? this.aString,


### PR DESCRIPTION
When running the generator with a nullable generic constraint, the nullable is removed. This PR fixes that.

---

Current behavior:

```dart
class FormState {
  const FormState({
    required this.validations,
  });

  final List<String?> validations; // Has a nullable generic
}
```

Generates this:

```dart
extension FormStateCopyWith on FormState {
  FormState copyWith({
    List<String>? validations, // Missing nullable generic
  }) {
    return FormState(
      validations: validations ?? this.validations,
    );
  }
}
```

This PR makes it so the nullable is retained:

```dart
extension FormStateCopyWith on FormState {
  FormState copyWith({
    List<String?>? validations, // Has nullable generic
  }) {
    return FormState(
      validations: validations ?? this.validations,
    );
  }
}
```