### PR TITLE
feat/mrgnhnt

### DIFF
--- a/copy_with_extension/lib/copy_with_extension.dart
+++ b/copy_with_extension/lib/copy_with_extension.dart
@@ -25,10 +25,10 @@ class CopyWith {
 /// Additional field related options for the `CopyWith`.
 @Target({TargetKind.field})
 class CopyWithField {
-  const CopyWithField({this.immutable = false});
+  const CopyWithField({this.immutable});
 
   /// Indicates that the field should be hidden in the generated `copyWith` method. By setting this flag to `true` the field will always be copied as it and excluded from `copyWith` interface.
-  final bool immutable;
+  final bool? immutable;
 }
 
 /// This placeholder object is a default value for nullable fields to handle cases when the user wants to nullify the value.

--- a/copy_with_extension/lib/copy_with_extension.dart
+++ b/copy_with_extension/lib/copy_with_extension.dart
@@ -1,7 +1,10 @@
 /// Provides `CopyWith` annotation class used by [copy_with_extension_gen](https://pub.dev/packages/copy_with_extension_gen).
 library copy_with_extension;
 
+import 'package:meta/meta_meta.dart';
+
 /// Annotation used to indicate that the `copyWith` extension should be generated.
+@Target({TargetKind.classType})
 class CopyWith {
   const CopyWith({
     this.copyWithNull,
@@ -20,6 +23,7 @@ class CopyWith {
 }
 
 /// Additional field related options for the `CopyWith`.
+@Target({TargetKind.field})
 class CopyWithField {
   const CopyWithField({this.immutable = false});
 

--- a/copy_with_extension/lib/copy_with_extension.dart
+++ b/copy_with_extension/lib/copy_with_extension.dart
@@ -4,16 +4,16 @@ library copy_with_extension;
 /// Annotation used to indicate that the `copyWith` extension should be generated.
 class CopyWith {
   const CopyWith({
-    this.copyWithNull = false,
-    this.skipFields = false,
+    this.copyWithNull,
+    this.skipFields,
     this.constructor,
   });
 
   /// Set `copyWithNull` to `true` if you want to use `copyWithNull` function that allows you to nullify the fields. E.g. `myInstance.copyWithNull(id: true, name: true)`.
-  final bool copyWithNull;
+  final bool? copyWithNull;
 
   /// Prevent the library from generating `copyWith` functions for individual fields e.g. `instance.copyWith.id("123")`. If you want to use only copyWith(...) function.
-  final bool skipFields;
+  final bool? skipFields;
 
   /// Set `constructor` if you want to use a named constructor. The generated fields will be derived from this constructor.
   final String? constructor;

--- a/copy_with_extension/pubspec.yaml
+++ b/copy_with_extension/pubspec.yaml
@@ -8,5 +8,8 @@ issue_tracker: https://github.com/numen31337/copy_with_extension/issues
 environment:
   sdk: ">=2.12.0 <3.0.0"
 
+dependencies:
+  meta: ^1.8.0
+
 dev_dependencies:
   flutter_lints: ^2.0.1

--- a/copy_with_extension_gen/README.md
+++ b/copy_with_extension_gen/README.md
@@ -123,6 +123,22 @@ class SimpleObject {
 }
 ```
 
+#### `build.yaml` configuration
+
+To globally configure the library, you can add a `build.yaml` file to your project. The following options are available:
+
+```yaml
+targets:
+  $default:
+    builders:
+
+      copy_with_extension_gen:
+        enabled: true
+        options:
+          copy_with_null: true # default is false
+          skip_fields: true # default is false
+```
+
 ## How this library is better than `freezed`?
 
 It isn't. This library is a non-intrusive alternative for those who only need the `copyWith` functionality and do not want to maintain the codebase in the way implied by the framework. This library only requires from your side the annotation of your class with `CopyWith()` and an indication of the `.part` file, everything else is up to you. [`freezed`](https://pub.dev/packages/freezed), on the other hand, offers many more code generation features but requires your models to be written in a framework-specific manner.

--- a/copy_with_extension_gen/lib/builder.dart
+++ b/copy_with_extension_gen/lib/builder.dart
@@ -9,14 +9,22 @@
 library copy_with_extension_gen.builder;
 
 import 'package:build/build.dart' show Builder, BuilderOptions;
+import 'package:copy_with_extension_gen/src/settings.dart';
 import 'package:source_gen/source_gen.dart' show SharedPartBuilder;
 import 'package:copy_with_extension_gen/src/copy_with_generator.dart';
+
+late Settings _settings;
+Settings get settings => _settings;
 
 /// Supports `package:build_runner` creation and configuration of
 /// `copy_with_extension_gen`.
 ///
 /// Not meant to be invoked by hand-authored code.
-Builder copyWith(BuilderOptions _) => SharedPartBuilder(
-      [CopyWithGenerator()],
-      'copyWith',
-    );
+Builder copyWith(BuilderOptions config) {
+  _settings = Settings.fromConfig(config.config);
+
+  return SharedPartBuilder(
+    [CopyWithGenerator()],
+    'copyWith',
+  );
+}

--- a/copy_with_extension_gen/lib/builder.dart
+++ b/copy_with_extension_gen/lib/builder.dart
@@ -10,11 +10,15 @@ library copy_with_extension_gen.builder;
 
 import 'package:build/build.dart' show Builder, BuilderOptions;
 import 'package:copy_with_extension_gen/src/settings.dart';
+import 'package:meta/meta.dart';
 import 'package:source_gen/source_gen.dart' show SharedPartBuilder;
 import 'package:copy_with_extension_gen/src/copy_with_generator.dart';
 
 late Settings _settings;
 Settings get settings => _settings;
+
+@visibleForTesting
+set settings(Settings value) => _settings = value;
 
 /// Supports `package:build_runner` creation and configuration of
 /// `copy_with_extension_gen`.

--- a/copy_with_extension_gen/lib/src/copy_with_annotation.dart
+++ b/copy_with_extension_gen/lib/src/copy_with_annotation.dart
@@ -1,0 +1,18 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
+
+class CopyWithAnnotation implements CopyWith {
+  const CopyWithAnnotation({
+    required this.constructor,
+    required this.copyWithNull,
+    required this.skipFields,
+  });
+
+  @override
+  final String? constructor;
+
+  @override
+  final bool copyWithNull;
+
+  @override
+  final bool skipFields;
+}

--- a/copy_with_extension_gen/lib/src/copy_with_field_annotation.dart
+++ b/copy_with_extension_gen/lib/src/copy_with_field_annotation.dart
@@ -1,0 +1,12 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
+
+class CopyWithFieldAnnotation implements CopyWithField {
+  const CopyWithFieldAnnotation({
+    required this.immutable,
+  });
+
+  const CopyWithFieldAnnotation.defaults() : this(immutable: false);
+
+  @override
+  final bool immutable;
+}

--- a/copy_with_extension_gen/lib/src/copy_with_generator.dart
+++ b/copy_with_extension_gen/lib/src/copy_with_generator.dart
@@ -51,58 +51,6 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
     ''';
   }
 
-  /// Generates the callable class function for copyWith(...).
-  String _copyWithValuesPart(
-    String typeAnnotation,
-    List<FieldInfo> sortedFields,
-    String? constructor,
-    bool skipFields,
-    bool isAbstract,
-  ) {
-    final constructorInput = sortedFields.fold<String>(
-      '',
-      (r, v) {
-        if (v.immutable) return r; // Skip the field
-
-        if (isAbstract) {
-          final type = v.type.endsWith('?') ? v.type : '${v.type}?';
-          return '$r $type ${v.name},';
-        } else {
-          return '$r Object? ${v.name} = const \$CopyWithPlaceholder(),';
-        }
-      },
-    );
-    final paramsInput = sortedFields.fold<String>(
-      '',
-      (r, v) {
-        if (v.immutable) return '$r ${v.name}: _value.${v.name},';
-        final nullCheckForNonNullable =
-            v.nullable ? "" : "|| ${v.name} == null";
-
-        return '''
-        $r ${v.name}:
-        ${v.name} == const \$CopyWithPlaceholder() $nullCheckForNonNullable
-        ? _value.${v.name}
-        // ignore: cast_nullable_to_non_nullable
-        : ${v.name} as ${v.type},''';
-      },
-    );
-
-    final constructorBody = isAbstract
-        ? ""
-        : "{ return ${constructorFor(typeAnnotation, constructor)}($paramsInput); }";
-
-    return '''
-        /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored.${skipFields ? "" : " You can also use `$typeAnnotation(...).copyWith.fieldName(...)` to override fields one at a time with nullification support."}
-        /// 
-        /// Usage
-        /// ```dart
-        /// $typeAnnotation(...).copyWith(id: 12, name: "My name")
-        /// ````
-        $typeAnnotation call({$constructorInput}) $constructorBody
-    ''';
-  }
-
   /// Generates the complete `copyWithNull` function.
   String _copyWithNullPart(
     String typeAnnotation,
@@ -191,6 +139,58 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
         @override
         ${_copyWithValuesPart(typeAnnotation, sortedFields, constructor, skipFields, false)}
       }
+    ''';
+  }
+
+  /// Generates the callable class function for copyWith(...).
+  String _copyWithValuesPart(
+    String typeAnnotation,
+    List<FieldInfo> sortedFields,
+    String? constructor,
+    bool skipFields,
+    bool isAbstract,
+  ) {
+    final constructorInput = sortedFields.fold<String>(
+      '',
+      (r, v) {
+        if (v.immutable) return r; // Skip the field
+
+        if (isAbstract) {
+          final type = v.type.endsWith('?') ? v.type : '${v.type}?';
+          return '$r $type ${v.name},';
+        } else {
+          return '$r Object? ${v.name} = const \$CopyWithPlaceholder(),';
+        }
+      },
+    );
+    final paramsInput = sortedFields.fold<String>(
+      '',
+      (r, v) {
+        if (v.immutable) return '$r ${v.name}: _value.${v.name},';
+        final nullCheckForNonNullable =
+            v.nullable ? "" : "|| ${v.name} == null";
+
+        return '''
+        $r ${v.name}:
+        ${v.name} == const \$CopyWithPlaceholder() $nullCheckForNonNullable
+        ? _value.${v.name}
+        // ignore: cast_nullable_to_non_nullable
+        : ${v.name} as ${v.type},''';
+      },
+    );
+
+    final constructorBody = isAbstract
+        ? ""
+        : "{ return ${constructorFor(typeAnnotation, constructor)}($paramsInput); }";
+
+    return '''
+        /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored.${skipFields ? "" : " You can also use `$typeAnnotation(...).copyWith.fieldName(...)` to override fields one at a time with nullification support."}
+        /// 
+        /// Usage
+        /// ```dart
+        /// $typeAnnotation(...).copyWith(id: 12, name: "My name")
+        /// ````
+        $typeAnnotation call({$constructorInput}) $constructorBody
     ''';
   }
 }

--- a/copy_with_extension_gen/lib/src/copy_with_generator.dart
+++ b/copy_with_extension_gen/lib/src/copy_with_generator.dart
@@ -32,6 +32,8 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
     final typeAnnotation = classElement.name + typeParametersNames;
 
     return '''
+    // ignore_for_file: unnecessary_non_null_assertion, duplicate_ignore
+
     ${_copyWithProxyPart(
       classAnnotation.constructor,
       classElement.name,
@@ -182,7 +184,7 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
 
         return paramEntry += '''
         ${v.name} == const \$CopyWithPlaceholder() $nullCheckForNonNullable
-        ? _value.${v.name}
+        ? _value.${v.name}${v.nullable ? '' : '!'}
         // ignore: cast_nullable_to_non_nullable
         : ${v.name} as ${v.type},''';
       },

--- a/copy_with_extension_gen/lib/src/copy_with_generator.dart
+++ b/copy_with_extension_gen/lib/src/copy_with_generator.dart
@@ -66,7 +66,7 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
     final nullConstructorInput = sortedFields.fold<String>(
       '',
       (r, v) {
-        if (v.immutable || !v.nullable) {
+        if (v.fieldAnnotation.immutable || !v.nullable) {
           return r;
         } else {
           return '$r bool ${v.name} = false,';
@@ -76,7 +76,7 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
     final nullParamsInput = sortedFields.fold<String>(
       '',
       (r, v) {
-        if (v.immutable || !v.nullable) {
+        if (v.fieldAnnotation.immutable || !v.nullable) {
           return '$r ${v.name}: ${v.name},';
         } else {
           return '$r ${v.name}: ${v.name} == true ? null : this.${v.name},';
@@ -110,7 +110,8 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
     bool skipFields,
   ) {
     final typeAnnotation = type + typeParameterNames;
-    final filteredFields = sortedFields.where((e) => !e.immutable);
+    final filteredFields =
+        sortedFields.where((e) => !e.fieldAnnotation.immutable);
 
     final nonNullableFunctions = skipFields ? "" : filteredFields.map((e) => '''
     @override
@@ -153,7 +154,7 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
     final constructorInput = sortedFields.fold<String>(
       '',
       (r, v) {
-        if (v.immutable) return r; // Skip the field
+        if (v.fieldAnnotation.immutable) return r; // Skip the field
 
         if (isAbstract) {
           final type = v.type.endsWith('?') ? v.type : '${v.type}?';
@@ -166,7 +167,10 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
     final paramsInput = sortedFields.fold<String>(
       '',
       (r, v) {
-        if (v.immutable) return '$r ${v.name}: _value.${v.name},';
+        if (v.fieldAnnotation.immutable) {
+          return '$r ${v.name}: _value.${v.name},';
+        }
+
         final nullCheckForNonNullable =
             v.nullable ? "" : "|| ${v.name} == null";
 

--- a/copy_with_extension_gen/lib/src/copy_with_generator.dart
+++ b/copy_with_extension_gen/lib/src/copy_with_generator.dart
@@ -170,8 +170,13 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
         final nullCheckForNonNullable =
             v.nullable ? "" : "|| ${v.name} == null";
 
-        return '''
-        $r ${v.name}:
+        var paramEntry = '$r ';
+
+        if (!v.isPositioned) {
+          paramEntry += '${v.name}:';
+        }
+
+        return paramEntry += '''
         ${v.name} == const \$CopyWithPlaceholder() $nullCheckForNonNullable
         ? _value.${v.name}
         // ignore: cast_nullable_to_non_nullable

--- a/copy_with_extension_gen/lib/src/field_info.dart
+++ b/copy_with_extension_gen/lib/src/field_info.dart
@@ -7,8 +7,11 @@ import 'package:source_gen/source_gen.dart' show ConstantReader, TypeChecker;
 
 /// Represents a single class field with the additional metadata needed for code generation.
 class FieldInfo {
-  FieldInfo(ParameterElement element, ClassElement classElement)
-      : name = element.name,
+  FieldInfo(
+    ParameterElement element,
+    ClassElement classElement, {
+    required this.isPositioned,
+  })  : name = element.name,
         type = element.type.getDisplayString(withNullability: true),
         immutable = _readFieldAnnotation(element, classElement).immutable,
         nullable = element.type.nullabilitySuffix != NullabilitySuffix.none;
@@ -17,6 +20,10 @@ class FieldInfo {
   final String name;
   final bool nullable;
   final String type;
+
+  /// if the field is positioned in the constructor
+
+  final bool isPositioned;
 
   @override
   String toString() {

--- a/copy_with_extension_gen/lib/src/field_info.dart
+++ b/copy_with_extension_gen/lib/src/field_info.dart
@@ -3,6 +3,7 @@ import 'package:analyzer/dart/element/element.dart'
     show ClassElement, FieldElement, ParameterElement;
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:copy_with_extension/copy_with_extension.dart';
+import 'package:copy_with_extension_gen/src/copy_with_field_annotation.dart';
 import 'package:source_gen/source_gen.dart' show ConstantReader, TypeChecker;
 
 /// Represents a single class field with the additional metadata needed for code generation.
@@ -13,10 +14,10 @@ class FieldInfo {
     required this.isPositioned,
   })  : name = element.name,
         type = element.type.getDisplayString(withNullability: true),
-        immutable = _readFieldAnnotation(element, classElement).immutable,
+        fieldAnnotation = _readFieldAnnotation(element, classElement),
         nullable = element.type.nullabilitySuffix != NullabilitySuffix.none;
 
-  final bool immutable;
+  final CopyWithFieldAnnotation fieldAnnotation;
   final String name;
   final bool nullable;
   final String type;
@@ -27,30 +28,32 @@ class FieldInfo {
 
   @override
   String toString() {
-    return 'type:$type name:$name immutable:$immutable nullable:$nullable';
+    return 'type:$type name:$name fieldAnnotation:$fieldAnnotation nullable:$nullable';
   }
 
   /// Restores the `CopyWithField` annotation provided by the user.
-  static CopyWithField _readFieldAnnotation(
+  static CopyWithFieldAnnotation _readFieldAnnotation(
     ParameterElement element,
     ClassElement classElement,
   ) {
+    const defaults = CopyWithFieldAnnotation.defaults();
+
     final fieldElement = classElement.getField(element.name);
     if (fieldElement is! FieldElement) {
-      return const CopyWithField();
+      return defaults;
     }
 
     const checker = TypeChecker.fromRuntime(CopyWithField);
     final annotation = checker.firstAnnotationOf(fieldElement);
     if (annotation is! DartObject) {
-      return const CopyWithField();
+      return defaults;
     }
 
     final reader = ConstantReader(annotation);
-    final immutable = reader.read('immutable').literalValue as bool?;
+    final immutable = reader.peek('immutable')?.boolValue;
 
-    return CopyWithField(
-      immutable: immutable ?? const CopyWithField().immutable,
+    return CopyWithFieldAnnotation(
+      immutable: immutable ?? defaults.immutable,
     );
   }
 }

--- a/copy_with_extension_gen/lib/src/field_info.dart
+++ b/copy_with_extension_gen/lib/src/field_info.dart
@@ -7,16 +7,16 @@ import 'package:source_gen/source_gen.dart' show ConstantReader, TypeChecker;
 
 /// Represents a single class field with the additional metadata needed for code generation.
 class FieldInfo {
-  final String name;
-  final String type;
-  final bool immutable;
-  final bool nullable;
-
   FieldInfo(ParameterElement element, ClassElement classElement)
       : name = element.name,
         type = element.type.getDisplayString(withNullability: true),
         immutable = _readFieldAnnotation(element, classElement).immutable,
         nullable = element.type.nullabilitySuffix != NullabilitySuffix.none;
+
+  final bool immutable;
+  final String name;
+  final bool nullable;
+  final String type;
 
   @override
   String toString() {

--- a/copy_with_extension_gen/lib/src/helpers.dart
+++ b/copy_with_extension_gen/lib/src/helpers.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/dart/element/element.dart'
     show ClassElement, ConstructorElement;
-import 'package:copy_with_extension/copy_with_extension.dart';
+import 'package:copy_with_extension_gen/builder.dart';
+import 'package:copy_with_extension_gen/src/copy_with_annotation.dart';
 import 'package:copy_with_extension_gen/src/field_info.dart';
 import 'package:source_gen/source_gen.dart'
     show ConstantReader, InvalidGenerationSourceError;
@@ -56,15 +57,15 @@ List<FieldInfo> sortedConstructorFields(
 }
 
 /// Restores the `CopyWith` annotation provided by the user.
-CopyWith readClassAnnotation(ConstantReader reader) {
-  final generateCopyWithNull = reader.read('copyWithNull').boolValue;
-  final skipFields = reader.read('skipFields').boolValue;
+CopyWithAnnotation readClassAnnotation(ConstantReader reader) {
+  final generateCopyWithNull = reader.peek('copyWithNull')?.boolValue;
+  final skipFields = reader.peek('skipFields')?.boolValue;
   final constructor = reader.peek('constructor')?.stringValue;
 
-  return CopyWith(
-    copyWithNull: generateCopyWithNull,
+  return CopyWithAnnotation(
+    copyWithNull: generateCopyWithNull ?? settings.copyWithNull,
+    skipFields: skipFields ?? settings.skipFields,
     constructor: constructor,
-    skipFields: skipFields,
   );
 }
 

--- a/copy_with_extension_gen/lib/src/helpers.dart
+++ b/copy_with_extension_gen/lib/src/helpers.dart
@@ -38,20 +38,17 @@ List<FieldInfo> sortedConstructorFields(
     );
   }
 
-  for (final parameter in parameters) {
-    if (!parameter.isNamed) {
-      final constructorName = targetConstructor.name.isEmpty
-          ? 'Unnamed constructor'
-          : 'Constructor "${targetConstructor.name}"';
-      throw InvalidGenerationSourceError(
-        '$constructorName for "${element.name}" contains unnamed parameter "${parameter.name}". Constructors annotated with "CopyWith" can contain only named parameters.',
-        element: element,
-      );
-    }
-  }
+  final fields = <FieldInfo>[];
 
-  final fields = parameters.map((v) => FieldInfo(v, element)).toList();
-  fields.sort((lhs, rhs) => lhs.name.compareTo(rhs.name));
+  for (final parameter in parameters) {
+    final field = FieldInfo(
+      parameter,
+      element,
+      isPositioned: parameter.isPositional,
+    );
+
+    fields.add(field);
+  }
 
   return fields;
 }

--- a/copy_with_extension_gen/lib/src/settings.dart
+++ b/copy_with_extension_gen/lib/src/settings.dart
@@ -1,0 +1,16 @@
+class Settings {
+  const Settings({
+    required this.copyWithNull,
+    required this.skipFields,
+  });
+
+  factory Settings.fromConfig(Map json) {
+    return Settings(
+      copyWithNull: json['copy_with_null'] as bool? ?? false,
+      skipFields: json['skip_fields'] as bool? ?? false,
+    );
+  }
+
+  final bool copyWithNull;
+  final bool skipFields;
+}

--- a/copy_with_extension_gen/pubspec.yaml
+++ b/copy_with_extension_gen/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   copy_with_extension: ^4.0.0
 
 dev_dependencies:
+  equatable: ^2.0.5
   flutter_lints: ^2.0.1
   build_runner: ">=1.11.5 <3.0.0"
   test: ^1.20.1

--- a/copy_with_extension_gen/pubspec.yaml
+++ b/copy_with_extension_gen/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   build: ^2.0.0
   source_gen: ^1.0.0
   copy_with_extension: ^4.0.0
+  meta: ^1.8.0
 
 dev_dependencies:
   equatable: ^2.0.5

--- a/copy_with_extension_gen/pubspec_overrides.yaml
+++ b/copy_with_extension_gen/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  copy_with_extension:
+    path: ../copy_with_extension

--- a/copy_with_extension_gen/test/gen_positioned_ctor_fields_test.dart
+++ b/copy_with_extension_gen/test/gen_positioned_ctor_fields_test.dart
@@ -1,0 +1,74 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
+import 'package:equatable/equatable.dart';
+import 'package:test/test.dart' show expect, group, setUp, test;
+
+part 'gen_positioned_ctor_fields_test.g.dart';
+
+@CopyWith()
+class PositionedFields extends Equatable {
+  const PositionedFields(
+    this.one,
+    this.oneAndAHalf, {
+    this.two,
+  });
+
+  final String one;
+  final String oneAndAHalf;
+  final String? two;
+
+  @override
+  List<Object?> get props => [one, oneAndAHalf, two];
+}
+
+void main() {
+  group('$PositionedFields', () {
+    late PositionedFields instance;
+
+    setUp(() {
+      instance = const PositionedFields(
+        'one',
+        'oneAndAHalf',
+        two: 'two',
+      );
+    });
+
+    test('one is replaced value', () {
+      const expected = PositionedFields(
+        'test',
+        'oneAndAHalf',
+        two: 'two',
+      );
+
+      expect(
+        instance.copyWith.one('test'),
+        expected,
+      );
+    });
+
+    test('oneAndAHalf is replaced value', () {
+      const expected = PositionedFields(
+        'one',
+        'test',
+        two: 'two',
+      );
+
+      expect(
+        instance.copyWith.oneAndAHalf('test'),
+        expected,
+      );
+    });
+
+    test('two is replaced value', () {
+      const expected = PositionedFields(
+        'one',
+        'oneAndAHalf',
+        two: 'test',
+      );
+
+      expect(
+        instance.copyWith.two('test'),
+        expected,
+      );
+    });
+  });
+}

--- a/copy_with_extension_gen/test/generated_code_test_cases/main_test.dart
+++ b/copy_with_extension_gen/test/generated_code_test_cases/main_test.dart
@@ -1,5 +1,7 @@
+import 'package:copy_with_extension_gen/builder.dart';
 import 'package:copy_with_extension_gen/src/copy_with_generator.dart';
 import 'package:copy_with_extension/copy_with_extension.dart';
+import 'package:copy_with_extension_gen/src/settings.dart';
 import 'package:source_gen_test/source_gen_test.dart'
     show
         initializeLibraryReaderForDirectory,
@@ -13,6 +15,8 @@ Future<void> main() async {
   );
 
   initializeBuildLogTracking();
+
+  settings = const Settings(copyWithNull: false, skipFields: false);
 
   testAnnotatedElements<CopyWith>(reader, CopyWithGenerator());
 }

--- a/copy_with_extension_gen/test/generated_code_test_cases/test_case_basic_usage.dart
+++ b/copy_with_extension_gen/test/generated_code_test_cases/test_case_basic_usage.dart
@@ -1,6 +1,8 @@
 part of 'source_gen_entrypoint.dart';
 
 @ShouldGenerate(r'''
+// ignore_for_file: unnecessary_non_null_assertion, duplicate_ignore
+
 abstract class _$BasicClassCWProxy<T extends Iterable<int>> {
   BasicClass<T> id(String id);
 
@@ -45,7 +47,7 @@ class _$BasicClassCWProxyImpl<T extends Iterable<int>>
   }) {
     return BasicClass<T>(
       id: id == const $CopyWithPlaceholder() || id == null
-          ? _value.id
+          ? _value.id!
           // ignore: cast_nullable_to_non_nullable
           : id as String,
       optional: optional == const $CopyWithPlaceholder()

--- a/copy_with_extension_gen/test/generated_code_test_cases/test_case_basic_usage.dart
+++ b/copy_with_extension_gen/test/generated_code_test_cases/test_case_basic_usage.dart
@@ -48,12 +48,12 @@ class _$BasicClassCWProxyImpl<T extends Iterable<int>>
           ? _value.id
           // ignore: cast_nullable_to_non_nullable
           : id as String,
-      immutable: _value.immutable,
-      nullableImmutable: _value.nullableImmutable,
       optional: optional == const $CopyWithPlaceholder()
           ? _value.optional
           // ignore: cast_nullable_to_non_nullable
           : optional as T?,
+      immutable: _value.immutable,
+      nullableImmutable: _value.nullableImmutable,
     );
   }
 }

--- a/copy_with_extension_gen/test/generated_code_test_cases/test_case_copy_with_null.dart
+++ b/copy_with_extension_gen/test/generated_code_test_cases/test_case_copy_with_null.dart
@@ -1,6 +1,8 @@
 part of 'source_gen_entrypoint.dart';
 
 @ShouldGenerate(r'''
+// ignore_for_file: unnecessary_non_null_assertion, duplicate_ignore
+
 abstract class _$_PrivateWithNullableWithoutFieldsCWProxy<
     T extends Iterable<int>> {
   /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored.

--- a/copy_with_extension_gen/test/generated_code_test_cases/test_cases_exceptions.dart
+++ b/copy_with_extension_gen/test/generated_code_test_cases/test_cases_exceptions.dart
@@ -23,36 +23,3 @@ class WrongConstructor {}
 class NoDefaultConstructor {
   NoDefaultConstructor.nonDefault();
 }
-
-@ShouldThrow(
-  'Unnamed constructor for "ConstructorWithSomeUnnamedFields" contains unnamed parameter "value". Constructors annotated with "CopyWith" can contain only named parameters.',
-)
-@CopyWith()
-class ConstructorWithSomeUnnamedFields {
-  int? test;
-  int value;
-
-  ConstructorWithSomeUnnamedFields(this.value, {this.test});
-}
-
-@ShouldThrow(
-  'Unnamed constructor for "ConstructorWithAllUnnamedFields" contains unnamed parameter "value". Constructors annotated with "CopyWith" can contain only named parameters.',
-)
-@CopyWith()
-class ConstructorWithAllUnnamedFields {
-  int? test;
-  int value;
-
-  ConstructorWithAllUnnamedFields(this.value, this.test);
-}
-
-@ShouldThrow(
-  'Constructor "test" for "NamedConstructorWithSomeUnnamedFields" contains unnamed parameter "value". Constructors annotated with "CopyWith" can contain only named parameters.',
-)
-@CopyWith(constructor: "test")
-class NamedConstructorWithSomeUnnamedFields {
-  int? test;
-  int value;
-
-  NamedConstructorWithSomeUnnamedFields.test(this.value, this.test);
-}


### PR DESCRIPTION
Hey @numen31337 👋

I have combined quite a few features/fixes into this PR, if you'd like for me to break them out into smaller PRs, I can do that.

Here's a breakdown of the PR:

### Settings

- Remove the default values from the annotation and change type to `nullable`
  - This is to know if the user has set a value to the annotation
- Move the default values to a new internal (builder pkg) class `CopyWithAnnotation`
- Add `options` to the `build.yaml` file to globally set the default values for
  - `copy_with_null`, `skip_fields`
- This also helps with scaling the number of options in the future

```yaml
targets:
  $default:
    builders:

      copy_with_extension_gen:
        enabled: true
        options:
          copy_with_null: true # default is false
          skip_fields: true # default is false
```

### Target Annotation

- Annotate `CopyWith` and `CopyWithField` with `@Target`
  - This is to help the analyzer provide lints to the user if they are using the annotations incorrectly
- `CopyWith` can only be annotated on a class
- `CopyWithField` can only be annotated on a field

### Allow positioned contructor parameters

- Currently the `CopyWith` annotation only allows for named parameters, this PR adds the ability to use positional parameters with named parameters
- Update/create tests for positioned constructor parameters

### Fix inline constructor type changes

- If a field is nullable, you can change the type of the constructor parameter to be non-nullable
  - This would cause the generated code to produce an error, so by refrencing the parameter type and using the `!` operator, we can avoid this error

### Update README

- Update the README to reflect to options in build.yaml file
