### PR TITLE
5.0.1 Nullability corrections

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -55,7 +55,13 @@ jobs:
         uses: zgosalvez/github-actions-analyze-dart@v1
 
       - name: Run tests
-        run: dart run test
+        run: |
+          warning_msg=`dart run test`
+          warning_formatted=${warning_msg//$'\n'/}
+          if [[ $warning_formatted =~ "Warning" ]]; then
+            echo $warning_msg
+            echo -n "::warning ::$warning_formatted"
+          fi
 
       - name: Check formatting
         run: dart format --set-exit-if-changed ../
@@ -94,7 +100,7 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           relativePath: copy_with_extension
-      
+
       - name: Check Files Are in Sync
         if: matrix.sdk == 'stable' && matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -55,13 +55,7 @@ jobs:
         uses: zgosalvez/github-actions-analyze-dart@v1
 
       - name: Run tests
-        run: |
-          warning_msg=`dart run test`
-          warning_formatted=${warning_msg//$'\n'/}
-          if [[ $warning_formatted =~ "Warning" ]]; then
-            echo $warning_msg
-            echo -n "::warning ::$warning_formatted"
-          fi
+        run: dart run test
 
       - name: Check formatting
         run: dart format --set-exit-if-changed ../
@@ -100,7 +94,7 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           relativePath: copy_with_extension
-
+      
       - name: Check Files Are in Sync
         if: matrix.sdk == 'stable' && matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -52,7 +52,7 @@ jobs:
         run: dart run build_runner build --delete-conflicting-outputs
 
       - name: Analyze
-        run: dart analyze
+        uses: zgosalvez/github-actions-analyze-dart@v1
 
       - name: Run tests
         run: dart run test

--- a/copy_with_extension/CHANGELOG.md
+++ b/copy_with_extension/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.0.1
+* [Fix](https://github.com/numen31337/copy_with_extension/issues/72) Warnings when using the `?` operator on a dynamic type.
+* [Fix](https://github.com/numen31337/copy_with_extension/issues/75) Warnings when using the `!` operator on a non-nullable type.
+* [Fix](https://github.com/numen31337/copy_with_extension/issues/74) Crash when object contains a dynamic field that is `null`.
+
 ## 5.0.0
 * Allow positioned constructor parameters (thanks [@mrgnhnt96](https://github.com/mrgnhnt96)).
 * Ability to define library defaults settings globally (thanks [@mrgnhnt96](https://github.com/mrgnhnt96)).

--- a/copy_with_extension/analysis_options.yaml
+++ b/copy_with_extension/analysis_options.yaml
@@ -1,9 +1,10 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
 
 linter:
   rules:

--- a/copy_with_extension/pubspec.yaml
+++ b/copy_with_extension/pubspec.yaml
@@ -1,5 +1,5 @@
 name: copy_with_extension
-version: 5.0.0
+version: 5.0.1
 description: Annotation for generating `copyWith` extensions code using `copy_with_extension_gen`.
 homepage: https://github.com/numen31337/copy_with_extension/tree/master/copy_with_extension
 repository: https://github.com/numen31337/copy_with_extension

--- a/copy_with_extension_gen/CHANGELOG.md
+++ b/copy_with_extension_gen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.0.1
+* [Fix](https://github.com/numen31337/copy_with_extension/issues/72) Warnings when using the `?` operator on a dynamic type.
+* [Fix](https://github.com/numen31337/copy_with_extension/issues/75) Warnings when using the `!` operator on a non-nullable type.
+* [Fix](https://github.com/numen31337/copy_with_extension/issues/74) Crash when object contains a dynamic field that is `null`.
+
 ## 5.0.0
 * Allow positioned constructor parameters (thanks [@mrgnhnt96](https://github.com/mrgnhnt96)).
 * Ability to define library defaults settings globally (thanks [@mrgnhnt96](https://github.com/mrgnhnt96)).

--- a/copy_with_extension_gen/analysis_options.yaml
+++ b/copy_with_extension_gen/analysis_options.yaml
@@ -1,9 +1,10 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
 
 linter:
   rules:

--- a/copy_with_extension_gen/lib/src/copy_with_generator.dart
+++ b/copy_with_extension_gen/lib/src/copy_with_generator.dart
@@ -59,7 +59,7 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
   /// Generates the complete `copyWithNull` function.
   String _copyWithNullPart(
     String typeAnnotation,
-    List<FieldInfo> sortedFields,
+    List<ConstructorParameterInfo> sortedFields,
     String? constructor,
     bool skipFields,
   ) {
@@ -111,7 +111,7 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
     String type,
     String typeParameters,
     String typeParameterNames,
-    List<FieldInfo> sortedFields,
+    List<ConstructorParameterInfo> sortedFields,
     bool skipFields,
   ) {
     final typeAnnotation = type + typeParameterNames;
@@ -151,7 +151,7 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
   /// Generates the callable class function for copyWith(...).
   String _copyWithValuesPart(
     String typeAnnotation,
-    List<FieldInfo> sortedFields,
+    List<ConstructorParameterInfo> sortedFields,
     String? constructor,
     bool skipFields,
     bool isAbstract,

--- a/copy_with_extension_gen/lib/src/copy_with_generator.dart
+++ b/copy_with_extension_gen/lib/src/copy_with_generator.dart
@@ -36,6 +36,16 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
     final typeParametersNames = typeParametersString(classElement, true);
     final typeAnnotation = classElement.name + typeParametersNames;
 
+    for (final field in sortedFields) {
+      if (field.classFieldInfo != null &&
+          field.nullable != field.classFieldInfo?.nullable) {
+        throw InvalidGenerationSourceError(
+          'The nullability of the constructor parameter "${field.name}" does not match the nullability of the corresponding field in the object.',
+          element: element,
+        );
+      }
+    }
+
     return '''
     ${_copyWithProxyPart(
       classAnnotation.constructor,

--- a/copy_with_extension_gen/lib/src/copy_with_generator.dart
+++ b/copy_with_extension_gen/lib/src/copy_with_generator.dart
@@ -180,11 +180,9 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
         final nullCheckForNonNullable =
             v.nullable ? "" : "|| ${v.name} == null";
 
-        /// INFO: The `!` operator here `? _value.${v.name}${v.classFieldInfo?.nullable != true ? '' : '!'}` is needed to overcome a possible issue described here https://github.com/numen31337/copy_with_extension/pull/69#issue-1433703875
-
         return '''$r ${v.isPositioned ? "" : '${v.name}:'}
         ${v.name} == const \$CopyWithPlaceholder() $nullCheckForNonNullable
-        ? _value.${v.name}${v.classFieldInfo?.nullable != true ? '' : '!'}
+        ? _value.${v.name}
         // ignore: cast_nullable_to_non_nullable
         : ${v.name} as ${v.type},''';
       },

--- a/copy_with_extension_gen/lib/src/copy_with_generator.dart
+++ b/copy_with_extension_gen/lib/src/copy_with_generator.dart
@@ -172,7 +172,8 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
         if (v.fieldAnnotation.immutable) return r; // Skip the field
 
         if (isAbstract) {
-          final type = v.type.endsWith('?') ? v.type : '${v.type}?';
+          final type =
+              v.type.endsWith('?') || v.isDynamic ? v.type : '${v.type}?';
           return '$r $type ${v.name},';
         } else {
           return '$r Object? ${v.name} = const \$CopyWithPlaceholder(),';

--- a/copy_with_extension_gen/lib/src/copy_with_generator.dart
+++ b/copy_with_extension_gen/lib/src/copy_with_generator.dart
@@ -180,11 +180,11 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
         final nullCheckForNonNullable =
             v.nullable ? "" : "|| ${v.name} == null";
 
-        /// The `!` operator is needed to overcome a possible issue described here https://github.com/numen31337/copy_with_extension/pull/69#issue-1433703875
+        /// INFO: The `!` operator here `? _value.${v.name}${v.classFieldInfo?.nullable != true ? '' : '!'}` is needed to overcome a possible issue described here https://github.com/numen31337/copy_with_extension/pull/69#issue-1433703875
+
         return '''$r ${v.isPositioned ? "" : '${v.name}:'}
         ${v.name} == const \$CopyWithPlaceholder() $nullCheckForNonNullable
-        ${v.nullable ? '' : '// ignore: unnecessary_non_null_assertion'}
-        ? _value.${v.name}${v.nullable ? '' : '!'}
+        ? _value.${v.name}${v.classFieldInfo?.nullable != true ? '' : '!'}
         // ignore: cast_nullable_to_non_nullable
         : ${v.name} as ${v.type},''';
       },

--- a/copy_with_extension_gen/lib/src/helpers.dart
+++ b/copy_with_extension_gen/lib/src/helpers.dart
@@ -8,7 +8,7 @@ import 'package:source_gen/source_gen.dart'
 
 /// Generates a list of `FieldInfo` for each class field that will be a part of the code generation process.
 /// The resulting array is sorted by the field name. `Throws` on error.
-List<FieldInfo> sortedConstructorFields(
+List<ConstructorParameterInfo> sortedConstructorFields(
   ClassElement element,
   String? constructor,
 ) {
@@ -38,10 +38,10 @@ List<FieldInfo> sortedConstructorFields(
     );
   }
 
-  final fields = <FieldInfo>[];
+  final fields = <ConstructorParameterInfo>[];
 
   for (final parameter in parameters) {
-    final field = FieldInfo(
+    final field = ConstructorParameterInfo(
       parameter,
       element,
       isPositioned: parameter.isPositional,

--- a/copy_with_extension_gen/lib/src/settings.dart
+++ b/copy_with_extension_gen/lib/src/settings.dart
@@ -5,7 +5,7 @@ class Settings {
     required this.skipFields,
   });
 
-  factory Settings.fromConfig(Map json) {
+  factory Settings.fromConfig(Map<String, dynamic> json) {
     return Settings(
       copyWithNull: json['copy_with_null'] as bool? ?? false,
       skipFields: json['skip_fields'] as bool? ?? false,

--- a/copy_with_extension_gen/pubspec.yaml
+++ b/copy_with_extension_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: copy_with_extension_gen
-version: 5.0.0
+version: 5.0.1
 description: Automatically generating `copyWith` extensions code for classes with `@CopyWith()` annotation.
 repository: https://github.com/numen31337/copy_with_extension
 homepage: https://github.com/numen31337/copy_with_extension/tree/master/copy_with_extension_gen

--- a/copy_with_extension_gen/test/gen_nullability_test.dart
+++ b/copy_with_extension_gen/test/gen_nullability_test.dart
@@ -6,15 +6,9 @@ part 'gen_nullability_test.g.dart';
 @CopyWith()
 class TestNullability {
   TestNullability(
-    // TODO: Must throw, have a test. This feature doesn't make sense as the constructor accepts non-nullable, but we can't guarantee it.
-    int this.nullableWithNonNullableConstructor,
     this.dynamicField,
     this.integers,
   );
-
-  /// https://github.com/numen31337/copy_with_extension/pull/69
-  /// If a field is nullable, you can change the type of the constructor parameter to be non-nullable.
-  final int? nullableWithNonNullableConstructor;
 
   /// https://github.com/numen31337/copy_with_extension/issues/74
   /// Test for crash on `instance.dynamicField!`.
@@ -29,21 +23,12 @@ class TestNullability {
 void main() {
   test('TestNullability', () {
     // Test for crash in both flows for `dynamicField`, when `dynamicField` is affected and not affected.
-    expect(TestNullability(1, 1, [1]).copyWith.integers([2]).dynamicField, 1);
-    expect(TestNullability(1, 1, [1]).copyWith.dynamicField(2).dynamicField, 2);
+    expect(TestNullability(1, [1]).copyWith.integers([2]).dynamicField, 1);
+    expect(TestNullability(1, [1]).copyWith.dynamicField(2).dynamicField, 2);
+    expect(TestNullability(1, [1]).copyWith(dynamicField: 2).dynamicField, 2);
+    expect(TestNullability(1, [1]).copyWith(integers: [1]).dynamicField, 1);
+    expect(TestNullability(null, [1]).copyWith.dynamicField(1).dynamicField, 1);
     expect(
-      TestNullability(1, 1, [1]).copyWith(dynamicField: 2).dynamicField,
-      2,
-    );
-    expect(
-      TestNullability(1, 1, [1])
-          .copyWith(nullableWithNonNullableConstructor: 1)
-          .dynamicField,
-      1,
-    );
-    expect(
-        TestNullability(1, null, [1]).copyWith.dynamicField(1).dynamicField, 1);
-    expect(TestNullability(1, null, [1]).copyWith.integers([2]).dynamicField,
-        null);
+        TestNullability(null, [1]).copyWith.integers([2]).dynamicField, null);
   });
 }

--- a/copy_with_extension_gen/test/gen_nullability_test.dart
+++ b/copy_with_extension_gen/test/gen_nullability_test.dart
@@ -40,5 +40,9 @@ void main() {
           .dynamicField,
       1,
     );
+    expect(
+        TestNullability(1, null, [1]).copyWith.dynamicField(1).dynamicField, 1);
+    expect(TestNullability(1, null, [1]).copyWith.integers([2]).dynamicField,
+        null);
   });
 }

--- a/copy_with_extension_gen/test/gen_nullability_test.dart
+++ b/copy_with_extension_gen/test/gen_nullability_test.dart
@@ -21,7 +21,7 @@ class TestNullability {
 
   /// https://github.com/numen31337/copy_with_extension/issues/75
   /// Warnings during compilation when using `!` on non-nullable value.
-  /// Use `dart compile exe test/gen_nullability_test.dart && rm -fr test/gen_nullability_test.exe ` to reproduce the warning.
+  /// Use `dart run copy_with_extension_gen/test/gen_nullability_test.dart` to reproduce the warning.
   final List<int> integers;
 }
 

--- a/copy_with_extension_gen/test/gen_nullability_test.dart
+++ b/copy_with_extension_gen/test/gen_nullability_test.dart
@@ -27,7 +27,18 @@ class TestNullability {
 
 void main() {
   test('TestNullability', () {
+    // Test for crash in both flows for `dynamicField`, when `dynamicField` is affected and not affected.
     expect(TestNullability(1, 1, [1]).copyWith.integers([2]).dynamicField, 1);
     expect(TestNullability(1, 1, [1]).copyWith.dynamicField(2).dynamicField, 2);
+    expect(
+      TestNullability(1, 1, [1]).copyWith(dynamicField: 2).dynamicField,
+      2,
+    );
+    expect(
+      TestNullability(1, 1, [1])
+          .copyWith(nullableWithNonNullableConstructor: 1)
+          .dynamicField,
+      1,
+    );
   });
 }

--- a/copy_with_extension_gen/test/gen_nullability_test.dart
+++ b/copy_with_extension_gen/test/gen_nullability_test.dart
@@ -1,0 +1,33 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
+import 'package:test/test.dart' show test, expect;
+
+part 'gen_nullability_test.g.dart';
+
+@CopyWith()
+class TestNullability {
+  TestNullability(
+    int this.nullableWithNonNullableConstructor,
+    this.dynamicField,
+    this.integers,
+  );
+
+  /// https://github.com/numen31337/copy_with_extension/pull/69
+  /// If a field is nullable, you can change the type of the constructor parameter to be non-nullable.
+  final int? nullableWithNonNullableConstructor;
+
+  /// https://github.com/numen31337/copy_with_extension/issues/74
+  /// Test for crash on `instance.dynamicField!`.
+  final dynamic dynamicField;
+
+  /// https://github.com/numen31337/copy_with_extension/issues/75
+  /// Warnings during compilation when using `!` on non-nullable value.
+  /// Use `dart compile exe test/gen_nullability_test.dart && rm -fr test/gen_nullability_test.exe ` to reproduce the warning.
+  final List<int> integers;
+}
+
+void main() {
+  test('TestNullability', () {
+    expect(TestNullability(1, 1, [1]).copyWith.integers([2]).dynamicField, 1);
+    expect(TestNullability(1, 1, [1]).copyWith.dynamicField(2).dynamicField, 2);
+  });
+}

--- a/copy_with_extension_gen/test/gen_nullability_test.dart
+++ b/copy_with_extension_gen/test/gen_nullability_test.dart
@@ -6,6 +6,7 @@ part 'gen_nullability_test.g.dart';
 @CopyWith()
 class TestNullability {
   TestNullability(
+    // TODO: Must throw, have a test. This feature doesn't make sense as the constructor accepts non-nullable, but we can't guarantee it.
     int this.nullableWithNonNullableConstructor,
     this.dynamicField,
     this.integers,

--- a/copy_with_extension_gen/test/generated_code_test_cases/custom_settings_test_case.dart
+++ b/copy_with_extension_gen/test/generated_code_test_cases/custom_settings_test_case.dart
@@ -36,8 +36,7 @@ class _$BasicClassCWProxyImpl<T extends Iterable<int>>
   }) {
     return BasicClass<T>(
       id: id == const $CopyWithPlaceholder() || id == null
-          // ignore: unnecessary_non_null_assertion
-          ? _value.id!
+          ? _value.id
           // ignore: cast_nullable_to_non_nullable
           : id as String,
       optional: optional == const $CopyWithPlaceholder()

--- a/copy_with_extension_gen/test/generated_code_test_cases/test_case_basic_usage.dart
+++ b/copy_with_extension_gen/test/generated_code_test_cases/test_case_basic_usage.dart
@@ -45,8 +45,7 @@ class _$BasicClassCWProxyImpl<T extends Iterable<int>>
   }) {
     return BasicClass<T>(
       id: id == const $CopyWithPlaceholder() || id == null
-          // ignore: unnecessary_non_null_assertion
-          ? _value.id!
+          ? _value.id
           // ignore: cast_nullable_to_non_nullable
           : id as String,
       optional: optional == const $CopyWithPlaceholder()
@@ -69,16 +68,12 @@ extension $BasicClassCopyWith<T extends Iterable<int>> on BasicClass<T> {
 class BasicClass<T extends Iterable<int>> {
   const BasicClass({
     required this.id,
-    this.dyn,
-    required String this.nullableFieldButNonNullableConstructor,
     this.optional,
     required this.immutable,
     required this.nullableImmutable,
   });
 
   final String id;
-  final dynamic dyn;
-  final String? nullableFieldButNonNullableConstructor;
   final T? optional;
   @CopyWithField(immutable: true)
   final int immutable;

--- a/copy_with_extension_gen/test/generated_code_test_cases/test_case_basic_usage.dart
+++ b/copy_with_extension_gen/test/generated_code_test_cases/test_case_basic_usage.dart
@@ -69,12 +69,16 @@ extension $BasicClassCopyWith<T extends Iterable<int>> on BasicClass<T> {
 class BasicClass<T extends Iterable<int>> {
   const BasicClass({
     required this.id,
+    this.dyn,
+    required String this.nullableFieldButNonNullableConstructor,
     this.optional,
     required this.immutable,
     required this.nullableImmutable,
   });
 
   final String id;
+  final dynamic dyn;
+  final String? nullableFieldButNonNullableConstructor;
   final T? optional;
   @CopyWithField(immutable: true)
   final int immutable;

--- a/copy_with_extension_gen/test/generated_code_test_cases/test_cases_exceptions.dart
+++ b/copy_with_extension_gen/test/generated_code_test_cases/test_cases_exceptions.dart
@@ -24,3 +24,17 @@ class WrongConstructor {}
 class NoDefaultConstructor {
   NoDefaultConstructor.nonDefault();
 }
+
+@ShouldThrow(
+  'The nullability of the constructor parameter "nullableWithNonNullableConstructor" does not match the nullability of the corresponding field in the object.',
+)
+@CopyWith()
+class TestNullability {
+  TestNullability(
+    int this.nullableWithNonNullableConstructor,
+  );
+
+  // Some info on this: https://github.com/numen31337/copy_with_extension/pull/69
+  // If a field is nullable, you can change the type of the constructor parameter to be non-nullable. However, if you do this, an exception may be thrown because the constructor only accepts non-nullable parameters. The issue is that we cannot guarantee that the parameter will be non-null when calling the constructor in the `copyWith` function. Therefore, even if the constructor constructs an object with a nullable field, it is currently impossible to achieve this in the implementation.
+  final int? nullableWithNonNullableConstructor;
+}


### PR DESCRIPTION
Corrections for the nullability feature introduced in https://github.com/numen31337/copy_with_extension/pull/69

- [x] Resolves: #74, 
- [x] Resolves: #75, 
- [x] Resolves: #72, 
- [x] Closes pr: https://github.com/numen31337/copy_with_extension/pull/76


CI Fixes:
- [x] Updating `actions/checkout` version
- [x] Dart Analyser shows errors on CI screen summary.