### PR TITLE
Allow analyzer v6

### DIFF
--- a/copy_with_extension_gen/pubspec.yaml
+++ b/copy_with_extension_gen/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=2.0.0 <6.0.0"
+  analyzer: ">=2.0.0 <7.0.0"
   build: ^2.0.0
   source_gen: ^1.0.0
   copy_with_extension: ^5.0.0


### PR DESCRIPTION
Version 6 of analyzer seems to only remove [deprecated code](https://pub.dev/packages/analyzer/changelog#600), no real breaking changes for copy_with_extension.