### PR TITLE
Fix constructor parameter resolution when initializers reference parameters or super constructors (#109, #110)

### DIFF
--- a/copy_with_extension_gen/lib/src/constructor_field_resolver.dart
+++ b/copy_with_extension_gen/lib/src/constructor_field_resolver.dart
@@ -26,12 +26,16 @@ class ConstructorFieldResolver {
   /// Returns the field name for [paramName] or `null` if the field
   /// cannot be resolved on this class or any annotated superclasses.
   String? resolve(String paramName) {
-    final forwarded = _forwardMap[paramName];
-    final candidate = forwarded ?? paramName;
-    if (_hasField(_classElement, candidate)) {
-      return candidate;
+    if (_hasField(_classElement, paramName)) {
+      return paramName;
     }
-    if (forwarded == null) return null;
+    final forwarded = _forwardMap[paramName];
+    if (forwarded == null) {
+      return null;
+    }
+    if (_hasField(_classElement, forwarded)) {
+      return forwarded;
+    }
     final superConstructor = _constructor.superConstructor2;
     final superClass = _classElement.supertype?.element3 as ClassElement2?;
     if (superConstructor == null || superClass == null) {

--- a/copy_with_extension_gen/test/gen_super_ctor_expression_test.dart
+++ b/copy_with_extension_gen/test/gen_super_ctor_expression_test.dart
@@ -47,6 +47,21 @@ class MultiParamChild extends Base {
   MultiParamChild({required int b, required int c}) : super(a: (b + c) ~/ 2);
 }
 
+@CopyWith()
+class BaseItem {
+  const BaseItem({this.focusNodeCount = 0});
+
+  final int focusNodeCount;
+}
+
+@CopyWith()
+class FormItem extends BaseItem {
+  FormItem({required this.quantities})
+      : super(focusNodeCount: quantities.length);
+
+  final List<String> quantities;
+}
+
 void main() {
   test('copyWith handles super initializer property access', () {
     final instance = Derived(b: 1);
@@ -88,5 +103,12 @@ void main() {
     final result = instance.copyWith(a: 5);
     expect(result, isA<MultiParamChild>());
     expect(result.a, 5);
+  });
+
+  test('copyWith handles local fields used in super initializer', () {
+    final item = FormItem(quantities: ['a', 'b']);
+    final copy = item.copyWith(quantities: ['x']);
+    expect(copy.quantities, ['x']);
+    expect(copy.focusNodeCount, 1);
   });
 }


### PR DESCRIPTION
Fixes  #109
Fixes #110

The bug described in issues #109 and #110 occurred when a subclass constructor forwarded one of its parameters into a super initializer that referenced that same parameter. The generator tried to resolve each constructor parameter to either a local field or a forwarded field in the inheritance chain. Because it checked forwarded mappings first, the parameter would incorrectly bind to the super initializer instead of the subclass field. When copyWith re‑used this mapping, it misaligned the fields and produced objects with swapped or corrupted values.

The fix changes the resolver order: it now verifies that the subclass declares a field with the same name before considering forwarded super‑constructor parameters. With this in place, parameters bind to their rightful fields, and inheritance no longer distorts the generated copy logic. A regression test using BaseItem and FormItem confirms that updating fields through copyWith preserves the correct mapping even when the superclass initializer references the parameter.