### PR TITLE
Add option to allow `null` as retain value for non-nullable fields in copyWith() (#115)

### DIFF
--- a/copy_with_extension/lib/copy_with_extension.dart
+++ b/copy_with_extension/lib/copy_with_extension.dart
@@ -11,6 +11,7 @@ class CopyWith {
     this.skipFields,
     this.constructor,
     this.immutableFields,
+    this.allowNullForNonNullableFields,
   });
 
   /// Set `copyWithNull` to `true` if you want to use `copyWithNull` function that allows you to nullify the fields. E.g. `myInstance.copyWithNull(id: true, name: true)`. Default is `false`.
@@ -26,6 +27,11 @@ class CopyWith {
   /// Fields can still opt out using `@CopyWithField(immutable: false)`.
   /// Defaults to `false`.
   final bool? immutableFields;
+
+  /// Makes non-nullable fields optional in copyWith operations when set to `true`.
+  /// This allows you to update only specific fields without providing values for other non-nullable fields.
+  /// Default is `false`.
+  final bool? allowNullForNonNullableFields;
 }
 
 /// Field related options for the class's `CopyWith` annotation.

--- a/copy_with_extension_gen/lib/src/annotation_utils.dart
+++ b/copy_with_extension_gen/lib/src/annotation_utils.dart
@@ -15,12 +15,16 @@ class AnnotationUtils {
     final skipFields = reader.peek('skipFields')?.boolValue;
     final constructor = reader.peek('constructor')?.stringValue;
     final immutableFields = reader.peek('immutableFields')?.boolValue;
+    final allowNullForNonNullableFields =
+        reader.peek('allowNullForNonNullableFields')?.boolValue;
 
     return CopyWithAnnotation(
       copyWithNull: generateCopyWithNull ?? settings.copyWithNull,
       skipFields: skipFields ?? settings.skipFields,
       constructor: constructor,
       immutableFields: immutableFields ?? settings.immutableFields,
+      allowNullForNonNullableFields: allowNullForNonNullableFields ??
+          settings.allowNullForNonNullableFields,
     );
   }
 }

--- a/copy_with_extension_gen/lib/src/copy_with_annotation.dart
+++ b/copy_with_extension_gen/lib/src/copy_with_annotation.dart
@@ -7,6 +7,7 @@ class CopyWithAnnotation implements CopyWith {
     required this.copyWithNull,
     required this.skipFields,
     required this.immutableFields,
+    required this.allowNullForNonNullableFields,
   });
 
   @override
@@ -20,4 +21,7 @@ class CopyWithAnnotation implements CopyWith {
 
   @override
   final bool immutableFields;
+
+  @override
+  final bool allowNullForNonNullableFields;
 }

--- a/copy_with_extension_gen/lib/src/copy_with_generator.dart
+++ b/copy_with_extension_gen/lib/src/copy_with_generator.dart
@@ -83,6 +83,8 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
       copyWithNull: generateCopyWithNull,
       constructor: resolvedConstructorName,
       superInfo: superInfo,
+      allowNullForNonNullableFields:
+          classAnnotation.allowNullForNonNullableFields,
     );
   }
 

--- a/copy_with_extension_gen/lib/src/settings.dart
+++ b/copy_with_extension_gen/lib/src/settings.dart
@@ -5,6 +5,7 @@ class Settings {
     required this.skipFields,
     required this.immutableFields,
     Set<String>? annotations,
+    this.allowNullForNonNullableFields = false,
   }) : annotations = (annotations ?? defaultAnnotations)
             .map((e) => e.toLowerCase())
             .toSet();
@@ -23,6 +24,8 @@ class Settings {
       copyWithNull: json['copy_with_null'] as bool? ?? false,
       skipFields: json['skip_fields'] as bool? ?? false,
       immutableFields: json['immutable_fields'] as bool? ?? false,
+      allowNullForNonNullableFields:
+          json['allow_null_for_non_nullable_fields'] as bool? ?? false,
       annotations: rawAnnotations,
     );
   }
@@ -31,6 +34,7 @@ class Settings {
   final bool skipFields;
   final bool immutableFields;
   final Set<String> annotations;
+  final bool allowNullForNonNullableFields;
 
   /// Default annotation names forwarded to generated parameters.
   static const defaultAnnotations = {'Deprecated'};

--- a/copy_with_extension_gen/lib/src/templates/copy_with_values_template.dart
+++ b/copy_with_extension_gen/lib/src/templates/copy_with_values_template.dart
@@ -4,6 +4,8 @@ import 'package:copy_with_extension_gen/src/constructor_utils.dart';
 /// Generates the body of the `call` method used by the proxy.
 /// The returned snippet can be used either as an abstract interface (when [isAbstract] is `true`)
 /// or as a concrete implementation that instantiates the target class.
+///
+/// param [allowNullForNonNullableFields] - if true, make non-nullable fields nullable, will be respected only when [isAbstract] is `true`
 String copyWithValuesTemplate(
   String typeAnnotation,
   List<ConstructorParameterInfo> allFields,
@@ -11,6 +13,7 @@ String copyWithValuesTemplate(
   String? constructor,
   bool skipFields,
   bool isAbstract, {
+  bool allowNullForNonNullableFields = false,
   bool addOverride = false,
 }) {
   // Build the parameter list for the generated function or abstract interface. Immutable fields are excluded entirely.
@@ -19,8 +22,12 @@ String copyWithValuesTemplate(
 
     final annotations = v.metadata.isEmpty ? '' : '${v.metadata.join(' ')} ';
     if (isAbstract) {
+      // If [allowNullForNonNullableFields] is true and field is non-nullable, make it nullable
+      final typeToUse = (allowNullForNonNullableFields && !v.nullable)
+          ? '${v.type}?'
+          : v.type;
       // When generating the interface, parameters are typed directly.
-      return '$r\n    $annotations${v.type} ${v.name},';
+      return '$r\n    $annotations$typeToUse ${v.name},';
     } else {
       // The implementation uses [\$CopyWithPlaceholder] to detect whether a parameter was passed.
       return '$r\n    ${annotations}Object? ${v.name} = const \$CopyWithPlaceholder(),';

--- a/copy_with_extension_gen/lib/src/templates/extension_template.dart
+++ b/copy_with_extension_gen/lib/src/templates/extension_template.dart
@@ -15,6 +15,7 @@ String extensionTemplate({
   required bool skipFields,
   required bool copyWithNull,
   required String? constructor,
+  required bool allowNullForNonNullableFields,
   AnnotatedCopyWithSuper? superInfo,
 }) {
   final typeAnnotation = className + typeParametersNames;
@@ -27,6 +28,7 @@ String extensionTemplate({
     fields,
     skipFields,
     superInfo: superInfo,
+    allowNullForNonNullableFields: allowNullForNonNullableFields,
   );
   final copyWithNullBlock = copyWithNull
       ? copyWithNullTemplate(typeAnnotation, fields, constructor, skipFields)

--- a/copy_with_extension_gen/lib/src/templates/proxy_template.dart
+++ b/copy_with_extension_gen/lib/src/templates/proxy_template.dart
@@ -14,6 +14,7 @@ String copyWithProxyTemplate(
   List<ConstructorParameterInfo> fields,
   bool skipFields, {
   AnnotatedCopyWithSuper? superInfo,
+  required bool allowNullForNonNullableFields,
 }) {
   final typeAnnotation = type + typeParameterNames;
   final filteredFields =
@@ -72,7 +73,7 @@ String copyWithProxyTemplate(
       abstract class _\$${type}CWProxy$typeParameters$extendsProxy {
         $nonNullableFunctionsInterface
 
-        ${copyWithValuesTemplate(typeAnnotation, fields, uniqueFilteredFields, constructor, skipFields, true, addOverride: superInfo != null)};
+        ${copyWithValuesTemplate(typeAnnotation, fields, uniqueFilteredFields, constructor, skipFields, true, addOverride: superInfo != null, allowNullForNonNullableFields: allowNullForNonNullableFields)};
       }
 
       /// Callable proxy for `copyWith` functionality.
@@ -85,7 +86,7 @@ String copyWithProxyTemplate(
         $nonNullableFunctions
 
         @override
-        ${copyWithValuesTemplate(typeAnnotation, fields, uniqueFilteredFields, constructor, skipFields, false)}
+        ${copyWithValuesTemplate(typeAnnotation, fields, uniqueFilteredFields, constructor, skipFields, false, allowNullForNonNullableFields: allowNullForNonNullableFields)}
       }
     ''';
 }

--- a/copy_with_extension_gen/test/gen_allow_null_for_non_nullable_fields_test.dart
+++ b/copy_with_extension_gen/test/gen_allow_null_for_non_nullable_fields_test.dart
@@ -1,0 +1,114 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
+import 'package:test/test.dart';
+
+part 'gen_allow_null_for_non_nullable_fields_test.g.dart';
+
+// Test default behavior (backward compatibility)
+@CopyWith()
+class DefaultClass {
+  const DefaultClass({required this.id, required this.name, this.email});
+
+  final int id;
+  final String name;
+  final String? email;
+}
+
+// Test with flag enabled via annotation
+@CopyWith(allowNullForNonNullableFields: true)
+class OptionalFieldsClass {
+  const OptionalFieldsClass({required this.id, required this.name, this.email});
+
+  final int id;
+  final String name;
+  final String? email;
+}
+
+// Test with generics
+@CopyWith(allowNullForNonNullableFields: true)
+class GenericClass<T> {
+  const GenericClass({required this.id, required this.value});
+
+  final int id;
+  final T value;
+}
+
+void main() {
+  group('Default behavior (backward compatibility)', () {
+    test('requires non-nullable fields', () {
+      final instance =
+          DefaultClass(id: 1, name: 'test', email: 'test@test.com');
+
+      // Should compile and work
+      instance.copyWith(id: 2);
+      instance.copyWith(name: 'new');
+      instance.copyWith(email: null);
+
+      // Should not compile:
+      // instance.copyWith(); // Error: missing required parameters
+    });
+  });
+
+  group('With allowNullForNonNullableFields enabled', () {
+    test('makes non-nullable fields optional', () {
+      final instance =
+          OptionalFieldsClass(id: 1, name: 'test', email: 'test@test.com');
+
+      // Should allow updating single fields without providing others
+      final result1 = instance.copyWith(id: 2);
+      expect(result1.id, 2);
+      expect(result1.name, 'test');
+      expect(result1.email, 'test@test.com');
+
+      final result2 = instance.copyWith(name: 'new');
+      expect(result2.id, 1);
+      expect(result2.name, 'new');
+      expect(result2.email, 'test@test.com');
+
+      // Should still allow updating multiple fields
+      final result3 = instance.copyWith(id: 3, name: 'both');
+      expect(result3.id, 3);
+      expect(result3.name, 'both');
+      expect(result3.email, 'test@test.com');
+
+      // Should allow empty copyWith
+      final result4 = instance.copyWith();
+      expect(result4.id, 1);
+      expect(result4.name, 'test');
+      expect(result4.email, 'test@test.com');
+    });
+
+    test('still respects field nullability', () {
+      final instance =
+          OptionalFieldsClass(id: 1, name: 'test', email: 'test@test.com');
+
+      // Should not allow null for non-nullable fields
+      // These should not compile:
+      // instance.copyWith(id: null);
+      // instance.copyWith(name: null);
+
+      // Should allow null for nullable fields
+      final result = instance.copyWith(email: null);
+      expect(result.email, null);
+    });
+  });
+
+  group('With generics', () {
+    test('handles non-nullable generic types', () {
+      final instance = GenericClass<String>(id: 1, value: 'test');
+
+      // Should allow updating just id
+      final result1 = instance.copyWith(id: 2);
+      expect(result1.id, 2);
+      expect(result1.value, 'test');
+
+      // Should allow updating just value
+      final result2 = instance.copyWith(value: 'new');
+      expect(result2.id, 1);
+      expect(result2.value, 'new');
+
+      // Should not allow null for non-nullable generic
+      // This should not compile:
+      // instance.copyWith(value: null);
+    });
+  });
+}


### PR DESCRIPTION
### Enh

- Introduced an opt-in flag to allow `null` values in `copyWith` calls for non-nullable fields, treating null as “retain old value.” Default strict behavior remains unchanged.

---

### Usage

**Option 1 – Annotation level:**

```dart
@CopyWith(allowNullForNonNullableFields: true)
class User {
  final String name;
  final String? email;
}
```

**Option 2 – build.yaml (global setting):**

```yaml
targets:
  $default:
    builders:
      copy_with_extension_gen|copy_with_extension:
        options:
          allow_null_for_non_nullable_fields: true
```

---

This way you cover **per-class opt-in** and **global opt-in**.
