### PR TITLE
Cross lib inheritance skip

### DIFF
--- a/copy_with_extension_gen/test/gen_inheritance_chain_test.dart
+++ b/copy_with_extension_gen/test/gen_inheritance_chain_test.dart
@@ -3,6 +3,8 @@ import 'dart:typed_data' as ns;
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:test/test.dart';
 
+import 'helpers/gen_cross_library_parent.dart' as cross_lib;
+
 part 'gen_inheritance_chain_test.g.dart';
 
 @CopyWith()
@@ -105,6 +107,13 @@ class ReorderParent<A, B> {
 @CopyWith()
 class ReorderChild<X, Y> extends ReorderParent<Y, X> {
   ReorderChild(super.a, super.b);
+}
+
+@CopyWith()
+class CrossLibraryChild extends cross_lib.CrossLibraryParent {
+  const CrossLibraryChild({required super.value, required this.child});
+
+  final int child;
 }
 
 @CopyWith()
@@ -257,6 +266,20 @@ void main() {
     final baseCopy = base.copyWith(value: const [4]);
     expect(baseCopy, isA<BaseBound<List<int>>>());
     expect(baseCopy.value, [4]);
+  });
+
+  test('copyWith inlines cross-library super proxies', () {
+    final child = CrossLibraryChild(value: 1, child: 2);
+
+    final delegated = child.copyWith.value(3);
+    expect(delegated, isA<CrossLibraryChild>());
+    expect(delegated.value, 3);
+    expect(delegated.child, 2);
+
+    final updated = child.copyWith(value: 4, child: 5);
+    expect(updated, isA<CrossLibraryChild>());
+    expect(updated.value, 4);
+    expect(updated.child, 5);
   });
 
   test('copyWith preserves subclass type with reordered generics', () {

--- a/copy_with_extension_gen/test/gen_inheritance_chain_test.dart
+++ b/copy_with_extension_gen/test/gen_inheritance_chain_test.dart
@@ -98,10 +98,10 @@ class BoundedChild<S extends int> extends BaseBound<List<S>> {
 }
 
 @CopyWith()
-class ReorderParent<A, B> {
+class ReorderParent<TFirst, TSecond> {
   ReorderParent(this.a, this.b);
-  final A a;
-  final B b;
+  final TFirst a;
+  final TSecond b;
 }
 
 @CopyWith()

--- a/copy_with_extension_gen/test/generated_code_test_cases/test_case_prefixed_superclass.dart
+++ b/copy_with_extension_gen/test/generated_code_test_cases/test_case_prefixed_superclass.dart
@@ -1,8 +1,7 @@
 part of 'source_gen_entrypoint.dart';
 
 @ShouldGenerate(r'''
-abstract class _$PrefixedSubclassCWProxy extends a._$PrefixedSuperCWProxy<int> {
-  @override
+abstract class _$PrefixedSubclassCWProxy {
   PrefixedSubclass superField(int superField);
 
   /// Creates a new instance with the provided field values.
@@ -12,22 +11,18 @@ abstract class _$PrefixedSubclassCWProxy extends a._$PrefixedSuperCWProxy<int> {
   /// ```dart
   /// PrefixedSubclass(...).copyWith(id: 12, name: "My name")
   /// ```
-  @override
   PrefixedSubclass call({int superField});
 }
 
 /// Callable proxy for `copyWith` functionality.
 /// Use as `instanceOfPrefixedSubclass.copyWith(...)` or call `instanceOfPrefixedSubclass.copyWith.fieldName(value)` for a single field.
-class _$PrefixedSubclassCWProxyImpl extends a._$PrefixedSuperCWProxyImpl<int>
-    implements _$PrefixedSubclassCWProxy {
-  const _$PrefixedSubclassCWProxyImpl(PrefixedSubclass super._value);
+class _$PrefixedSubclassCWProxyImpl implements _$PrefixedSubclassCWProxy {
+  const _$PrefixedSubclassCWProxyImpl(this._value);
+
+  final PrefixedSubclass _value;
 
   @override
-  PrefixedSubclass get _value => super._value as PrefixedSubclass;
-
-  @override
-  PrefixedSubclass superField(int superField) =>
-      super.superField(superField) as PrefixedSubclass;
+  PrefixedSubclass superField(int superField) => call(superField: superField);
 
   @override
   /// Creates a new instance with the provided field values.

--- a/copy_with_extension_gen/test/helpers/gen_cross_library_parent.dart
+++ b/copy_with_extension_gen/test/helpers/gen_cross_library_parent.dart
@@ -1,0 +1,10 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
+
+part 'gen_cross_library_parent.g.dart';
+
+@CopyWith()
+class CrossLibraryParent {
+  const CrossLibraryParent({required this.value});
+
+  final int value;
+}


### PR DESCRIPTION
Update the proxy generator to inherit from annotated super proxies only when they share the same library, inlining the implementation otherwise to avoid referencing private types across boundaries. Added a minimal cross-library regression test and shared base class to ensure subclasses continue to expose working copyWith methods when their annotated parent lives in another library.

Solves #114.